### PR TITLE
Add cabinet filter and popups to map

### DIFF
--- a/components/Filters.js
+++ b/components/Filters.js
@@ -1,13 +1,46 @@
 import React from 'react';
-import { Card, Row } from 'reactstrap';
+import { Card, Row, Form, Input } from 'reactstrap';
+import PropTypes from 'prop-types';
 
-export default function Filters() {
+export default function Filters(props) {
   return (
     <div>
       <Row className="ml-1">
-        <h5 className="mt-3 font-weight-bold text-uppercase">Filters</h5>
+        <h5 className="mt-3 font-weight-bold text-uppercase">
+          Filter Projects:
+        </h5>
       </Row>
-      <Card className="border-0">Filters placeholder</Card>
+      <Card className="border-0">
+        <Form>
+          <div className="sel">
+            <div className="sel-c sel-c--fw">
+              <Input
+                type="select"
+                name="selectCabinet"
+                id="selectCabinet"
+                onChange={props.cabinetChange}
+                value={props.cabinetSelection}
+                className="sef-f"
+              >
+                <option>All</option>
+                <option>Arts & Culture</option>
+                <option>Economic Development Cabinet</option>
+                <option>Environment, Energy & Open Space</option>
+                <option>Education</option>
+                <option>Health & Human Services</option>
+                <option>Housing & Neighborhood Development</option>
+                <option>Operations</option>
+                <option>Public Safety</option>
+                <option>Streets</option>
+              </Input>
+            </div>
+          </div>
+        </Form>
+      </Card>
     </div>
   );
 }
+Filters.propTypes = {
+  cabinetChange: PropTypes.func,
+  cabinetSelection: PropTypes.string,
+};

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -66,29 +66,34 @@ export default class Layout extends React.Component {
             padding: 0.2rem !important;
           }
 
-          // filter button styles
-          .btn-outline-primary {
-            color: #091f2f;
-            border-color: #d2d2d2;
-          }
-          .btn {
-            border-radius: 0;
-          }
-          .btn-outline-primary.active,
-          .btn-outline-primary:active,
-          .btn-outline-primary:hover {
-            background-color: #288be4 !important;
-            border-color: #d2d2d2 !important;
-          }
+          // select dropdown styles
           .form-control {
-            border-radius: 0;
-            border-color: #d2d2d2;
+            border: 3px solid #091f2f;
+            font-family: 'Lora', serif;
+            font-style: italic;
           }
         `}</style>
         {/* set container div with room for navbar  */}
         <div style={{ minHeight: 'calc(100vh - 125px)' }}>
           <Navbar>
-            <h3>Capital Projects FY2019-FY2023</h3>
+            <div>
+              <h2
+                className="text-uppercase font-weight-bold m-0 pr-2"
+                style={{
+                  display: 'inline-block',
+                }}
+              >
+                Capital Projects
+              </h2>
+              <p
+                className="font-italic m-0"
+                style={{
+                  display: 'inline-block',
+                }}
+              >
+                Fiscal Years 2019-2023
+              </p>
+            </div>
             <div className="lo">
               <div className="lo-l">
                 <a href="https://www.boston.gov/">

--- a/components/Map.js
+++ b/components/Map.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // We can't import these server-side because they require "window"
 const mapboxgl = process.browser ? require('mapbox-gl') : null;
@@ -6,12 +7,19 @@ const mapboxgl = process.browser ? require('mapbox-gl') : null;
 const projects_url =
   'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/FY2019_FY2023_Budget_Facilities_ADOPTED/FeatureServer/0';
 
+const public_works_ramps_url =
+  'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/BudgetFacilitiesFY2019/FeatureServer/2';
+
+const city_council_districts_url =
+  'https://services.arcgis.com/sFnw0xNflSi8J0uh/arcgis/rest/services/City_Council_Districts_View/FeatureServer/0';
+
 class Map extends React.Component {
   componentDidMount() {
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
-      center: [-71.067449, 42.352568],
-      zoom: 13,
+      center: [-71.084578, 42.309578],
+      zoom: 11,
+      maxZoom: 19,
       style: {
         version: 8,
         // Despite mapbox enabling vector basemaps, we use our own tiled
@@ -52,21 +60,149 @@ class Map extends React.Component {
     });
 
     this.map.on('load', () => {
-      // We add the capital projects as geojson
-      this.map.addSource('projects', {
+      // Add city council districts as a contextual layer.
+      this.map.addSource('cityCounilDistricts-polygon', {
+        type: 'geojson',
+        data: `${city_council_districts_url}/query?where=1%3D1&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+      });
+
+      this.map.addLayer({
+        id: 'cityCouncilDistricts',
+        type: 'line',
+        source: 'cityCounilDistricts-polygon',
+        paint: {
+          'line-color': '#091F2F',
+        },
+      });
+
+      // Add the public works ramps as a layer.
+      this.map.addSource('publicWorksRamps-point', {
+        type: 'geojson',
+        data: `${public_works_ramps_url}/query?where=1%3D1&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
+      });
+
+      this.map.addLayer({
+        id: 'publicWorksRamps',
+        type: 'circle',
+        source: 'publicWorksRamps-point',
+        paint: {
+          'circle-stroke-width': 1,
+          'circle-stroke-color': '#091F2F',
+          'circle-color': '#c1c1c1',
+          // Make circles larger as the user zooms from 12 to 22.
+          'circle-radius': {
+            base: 3,
+            stops: [[12, 3], [17, 10]],
+          },
+        },
+      });
+
+      // Add the budget facilities as a layer.
+      this.map.addSource('budgetFacilities-point', {
         type: 'geojson',
         data: `${projects_url}/query?where=1%3D1&outFields=*&outSR=4326&returnExceededLimitFeatures=true&f=pgeojson`,
       });
 
       this.map.addLayer({
-        id: 'projects-point',
+        id: 'budgetFacilities',
         type: 'circle',
-        source: 'projects',
+        source: 'budgetFacilities-point',
         paint: {
           'circle-stroke-width': 1,
+          'circle-stroke-color': '#091F2F',
+          'circle-color': '#288BE4',
+          // Make circles larger as the user zooms from 12 to 22.
+          'circle-radius': {
+            base: 4,
+            stops: [[12, 4], [17, 10]],
+          },
         },
       });
     });
+
+    // Add pop-ups to map
+    this.map.on('click', e => {
+      // Budget aggregates the data so there is only one project per
+      // feature (no projects overlap eachother), so we only grab the
+      // first feature clicked on.
+      const feature = this.map.queryRenderedFeatures(e.point)[0];
+      const dataset = feature.layer.id;
+      // Feature properties can differ based on the data selected.
+      const properties =
+        dataset == 'budgetFacilities'
+          ? [
+              feature.properties.Project_Title,
+              feature.properties.Project_Description,
+              feature.properties.Publish_Status,
+              feature.properties.Total_Budget,
+              feature.properties.Department,
+              feature.properties.Cabinet,
+            ]
+          : [
+              // Set the properties for publicWorksRamps.
+              feature.properties.Street,
+              feature.properties.NAME,
+              feature.properties.CITYCODE,
+              feature.properties.CONDITION,
+            ];
+
+      new mapboxgl.Popup({ closeOnClick: true })
+        .setLngLat(feature.geometry.coordinates)
+        // We create HTML elements for the populated properties.
+        .setHTML(
+          `<div style="min-width: 200px; max-width: 250px">
+        <div>
+            <ul class="dl dl--sm">
+              <li class="dl-i dl-i--b">
+                <div class="dl-d">${properties[0]}</div>
+              </li>        
+              <li class="dl-i dl-i--b">
+                <div class="dl-t">
+                ${properties[2] ? `${properties[2]}<br/>` : ''}
+                ${properties[3] ? `${properties[3]}<br/>` : ''}
+                ${properties[4] ? `${properties[4]}<br/>` : ''}
+                ${properties[5] ? `${properties[5]}` : ''}
+                </div>
+              </li>
+            </ul>
+        </div>`
+        )
+        .addTo(this.map);
+    });
+
+    // When we scroll over a point, change the mouse to a pointer.
+    this.map.on('mousemove', e => {
+      const features = this.map.queryRenderedFeatures(e.point, {
+        layers: ['budgetFacilities', 'publicWorksRamps'],
+      });
+
+      features.length > 0
+        ? (this.map.getCanvas().style.cursor = 'pointer')
+        : (this.map.getCanvas().style.cursor = '');
+    });
+  }
+
+  // When the cabinet selection changes, we update the map accordingly.
+  componentDidUpdate(prevProps) {
+    if (prevProps.cabinetSelection !== this.props.cabinetSelection) {
+      if (this.props.cabinetSelection == 'All') {
+        this.map.setLayoutProperty('publicWorksRamps', 'visibility', 'visible');
+        this.map.setFilter('budgetFacilities', ['all']);
+        // The public works data is stored in a different layer, but is part of the
+        // 'Streets' cabinet. When 'Streets' is selected, we make the public works
+        // layer visible and turn it off when other cabinets are selected.
+      } else if (this.props.cabinetSelection == 'Streets') {
+        this.map.setLayoutProperty('publicWorksRamps', 'visibility', 'visible');
+        this.map.setFilter('budgetFacilities', ['==', 'Cabinet', 'Streets']);
+      } else {
+        this.map.setLayoutProperty('publicWorksRamps', 'visibility', 'none');
+        this.map.setFilter('budgetFacilities', [
+          '==',
+          'Cabinet',
+          this.props.cabinetSelection,
+        ]);
+      }
+    }
   }
 
   componentWillUnmount() {
@@ -87,3 +223,7 @@ class Map extends React.Component {
 }
 
 export default Map;
+
+Map.propTypes = {
+  cabinetSelection: PropTypes.string,
+};

--- a/components/Map.js
+++ b/components/Map.js
@@ -158,10 +158,7 @@ class Map extends React.Component {
               </li>        
               <li class="dl-i dl-i--b">
                 <div class="dl-t">
-                ${properties[2] ? `${properties[2]}<br/>` : ''}
-                ${properties[3] ? `${properties[3]}<br/>` : ''}
-                ${properties[4] ? `${properties[4]}<br/>` : ''}
-                ${properties[5] ? `${properties[5]}` : ''}
+                ${properties.map(property => `${property}`).join('<br/>')}
                 </div>
               </li>
             </ul>

--- a/components/MapContainer.js
+++ b/components/MapContainer.js
@@ -3,15 +3,36 @@ import { Col, Row } from 'reactstrap';
 import Filters from '../components/Filters';
 import Map from '../components/Map';
 
-export default function MapContainer() {
-  return (
-    <Row>
-      <Col lg="3">
-        <Filters />
-      </Col>
-      <Col lg="9" className="p-lg-0 pr-md-5 pl-md-5">
-        <Map />
-      </Col>
-    </Row>
-  );
+class MapContainer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      cabinetSelection: 'All',
+    };
+  }
+
+  // We update cabinetSelection state when the
+  // selection changes.
+  filterCabinets = e => {
+    this.setState({ cabinetSelection: e.target.value });
+  };
+
+  render() {
+    return (
+      <Row>
+        <Col lg="3">
+          <Filters
+            cabinetSelection={this.state.cabinetSelection}
+            cabinetChange={this.filterCabinets}
+          />
+        </Col>
+        <Col lg="9" className="p-lg-0 pr-md-5 pl-md-5">
+          <Map cabinetSelection={this.state.cabinetSelection} />
+        </Col>
+      </Row>
+    );
+  }
 }
+
+export default MapContainer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "vision-zero",
+  "name": "capital-projects",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This PR:
- adds more datasets to the map
- adds a filter for cabinets 
- adds popups to the features

Question: to update the map based on the filters changes I used componentWillRecieveProps in the vision zero map. Looks like that function has been [depreciated](https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops). I used [componentDidUpdate](https://reactjs.org/docs/react-component.html#componentdidupdate) instead - is that what I should be using now?